### PR TITLE
Updating params to new format and fixing typo

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,11 +64,11 @@ func zipHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	params := r.URL.Query()
-	if len(params["subscriber.zipcode"]) > 0 {
-		zipcode := ZipCode(params["subscriber.zipcode"][0])
+	if len(params["subscriber[zipcode]"]) > 0 {
+		zipcode := ZipCode(params["subscriber[zipcode]"][0])
 		writableForecast, err := getForecastResponse(zipcode)
 		if err != nil {
-			log.Printf("Error when getting forecat: %s", err.Error())
+			log.Printf("Error when getting forecast: %s", err.Error())
 			http.Error(w, "Internal server error", 500)
 			return
 		}


### PR DESCRIPTION
FWIW I tested and confirmed that this works with both url-escaped brackets, _and_ unescaped.

```
➜ curl "http://localhost:8080/api?subscriber\[zipcode\]=55379"
{"apparentTemperature":61.43,"cloudCover":1,"dewPoint":60.24,"humidity":0.97,"icon":"rain","ozone":256.21,"precipIntensity":0.0155,"precipProbability":0.99,"precipType":"rain","pressure":1013.38,"summary":"Light Rain","temperature":61.06,"time":1537451670,"uvIndex":1,"visibility":5.06,"windBearing":71,"windGust":9.78,"windSpeed":5.99}

➜ curl "http://localhost:8080/api?subscriber%5Bzipcode%5D=55379"
{"apparentTemperature":61.45,"cloudCover":1,"dewPoint":60.27,"humidity":0.97,"icon":"rain","ozone":256.2,"precipIntensity":0.0131,"precipProbability":0.99,"precipType":"rain","pressure":1013.35,"summary":"Light Rain","temperature":61.07,"time":1537451755,"uvIndex":1,"visibility":5.05,"windBearing":71,"windGust":9.91,"windSpeed":6.03}
```

Also, that's some amazing precision that these numbers all moved by a few decimal points in the seconds between my two calls...